### PR TITLE
chore: scaffold backend and frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 data/
 __pycache__/
 *.pyc
+node_modules/
+frontend/dist/
+draft_state.json
+.env

--- a/README.md
+++ b/README.md
@@ -2,13 +2,38 @@
 
 Prototype modules for a fantasy football helper app.
 
-## Features
-- Download play-by-play data from the NFL fastR dataset.
-- Access Fantasy Football Nerd endpoints for players, injuries, and projections (API key required via `FFN_API_KEY`).
-- Simple scoring engine that calculates points based on customizable rules.
+## Project Structure
 
-## Usage
+```
+backend/    FastAPI application and data utilities
+frontend/   React client served by Vite
+scoring/    Fantasy scoring rules and calculators
+utils/      Misc helper functions
+```
+
+## Dependencies
+
+Backend requirements are listed in `requirements.txt` and include FastAPI and Uvicorn. The frontend uses React with Vite; see `frontend/package.json` for npm dependencies.
+
+## Running the Backend
+
 ```bash
 pip install -r requirements.txt
-python main.py
+uvicorn backend.app:app --reload
 ```
+
+## Running the Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Data Integration Outline
+
+- `backend/ffn_api.py` wraps the Fantasy Football Nerd API (requires an API key via `FFN_API_KEY`).
+- `backend/nfl_data.py` fetches play-by-play data from the NFL fastR repository.
+- `backend/data_service.py` demonstrates merging these sources into a single player pool loaded at server startup.
+
+This skeleton sets up the draft state management and provides a minimal React UI that lists available players. Further features—such as custom scoring, draft recommendations, and advanced analytics—can be built on top of this foundation.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI, HTTPException
+from .data_service import load_player_pool
+from .store import DraftState
+
+app = FastAPI(title="Draft Day Assistant")
+state = DraftState.load()
+
+@app.on_event("startup")
+def startup() -> None:
+    """Load player data at startup."""
+    players = load_player_pool()
+    state.set_players(players)
+
+
+@app.get("/players")
+def get_players() -> list:
+    """Return all available players."""
+    return state.available_players
+
+
+@app.post("/draft/pick")
+def pick_player(player_id: str, team: int) -> dict:
+    """Record a draft pick and remove the player from the pool."""
+    try:
+        state.make_pick(player_id, team)
+    except ValueError as exc:  # pragma: no cover - simple example
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"ok": True}
+
+
+@app.post("/draft/undo")
+def undo_pick() -> dict:
+    """Undo the last pick."""
+    state.undo_pick()
+    return {"ok": True}
+
+
+@app.get("/state")
+def get_state() -> dict:
+    """Return the full draft state."""
+    return state.to_dict()

--- a/backend/data_service.py
+++ b/backend/data_service.py
@@ -1,0 +1,46 @@
+"""Utilities for loading and merging player data."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .ffn_api import get_players, get_injuries
+from .nfl_data import get_play_by_play
+
+
+def load_player_pool(year: int = 2023) -> List[Dict]:
+    """Return a list of player dictionaries ready for drafting.
+
+    The function combines:
+    - Fantasy Football Nerd player list and current injuries.
+    - Historical play-by-play data from NFL fastR for simple metrics
+      such as games played or missed.
+
+    Full stat/projection merging is left as a future enhancement.
+    """
+    ffn_players = get_players()
+    injuries = get_injuries()
+
+    injury_map = {i.get("playerId"): i for i in injuries.get("Injuries", [])}
+    players = []
+    for p in ffn_players.get("Players", []):
+        pid = p.get("playerId")
+        players.append(
+            {
+                "id": pid,
+                "name": p.get("displayName"),
+                "position": p.get("position"),
+                "team": p.get("team"),
+                "injury": injury_map.get(pid),
+                # Placeholder: real implementation would merge stats from fastR
+                "rookie": False,
+            }
+        )
+
+    # Placeholder call to show how fastR data could be incorporated
+    try:
+        pbp = get_play_by_play(year)
+        _ = len(pbp)  # suppress unused variable warning
+    except Exception:  # pragma: no cover - network may fail in tests
+        pass
+
+    return players

--- a/backend/store.py
+++ b/backend/store.py
@@ -1,0 +1,58 @@
+"""Simple JSON file persistence for draft state."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List
+
+STATE_FILE = Path("draft_state.json")
+
+
+@dataclass
+class DraftState:
+    teams: int = 12
+    picks: List[Dict[str, Any]] = field(default_factory=list)
+    available_players: List[Dict[str, Any]] = field(default_factory=list)
+    filename: Path = STATE_FILE
+
+    def set_players(self, players: List[Dict[str, Any]]) -> None:
+        self.available_players = players
+        self._save()
+
+    def make_pick(self, player_id: str, team: int) -> None:
+        player = next((p for p in self.available_players if p["id"] == player_id), None)
+        if not player:
+            raise ValueError("Player not available")
+        self.available_players = [p for p in self.available_players if p["id"] != player_id]
+        self.picks.append({"team": team, "player": player})
+        self._save()
+
+    def undo_pick(self) -> None:
+        if not self.picks:
+            return
+        last = self.picks.pop()
+        self.available_players.append(last["player"])
+        self._save()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "teams": self.teams,
+            "picks": self.picks,
+            "available_players": self.available_players,
+        }
+
+    def _save(self) -> None:
+        self.filename.write_text(json.dumps(self.to_dict()))
+
+    @classmethod
+    def load(cls, filename: Path = STATE_FILE) -> "DraftState":
+        if filename.exists():
+            data = json.loads(filename.read_text())
+            return cls(
+                teams=data.get("teams", 12),
+                picks=data.get("picks", []),
+                available_players=data.get("available_players", []),
+                filename=filename,
+            )
+        return cls(filename=filename)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Fantasy Draft Assistant</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "fflapp-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.3",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+interface Player {
+  id: string
+  name: string
+  position: string
+}
+
+function App() {
+  const [players, setPlayers] = useState<Player[]>([])
+
+  useEffect(() => {
+    axios.get('/api/players').then((resp) => setPlayers(resp.data))
+  }, [])
+
+  return (
+    <div>
+      <h1>Fantasy Draft Assistant</h1>
+      <ul>
+        {players.map((p) => (
+          <li key={p.id}>{p.name} - {p.position}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pandas
 requests
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- bootstrap FastAPI backend with draft state management and player endpoints
- add React/Vite frontend placeholder that lists available players from backend
- document project structure, dependencies, and data integration approach

## Testing
- `pytest`
- `npm --prefix frontend test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689185334dcc8321a9157a753f71e8e2