### PR TITLE
Add default Fantasy Football Nerd API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm run dev
 
 ## Data Integration Outline
 
-- `backend/ffn_api.py` wraps the Fantasy Football Nerd API (requires an API key via `FFN_API_KEY`).
+- `backend/ffn_api.py` wraps the Fantasy Football Nerd API (uses the `FFN_API_KEY` environment variable and defaults to the key `TEST`).
 - `backend/nfl_data.py` fetches play-by-play data from the NFL fastR repository.
 - `backend/data_service.py` demonstrates merging these sources into a single player pool loaded at server startup.
 

--- a/backend/ffn_api.py
+++ b/backend/ffn_api.py
@@ -5,10 +5,11 @@ import requests
 from typing import Any, Dict
 
 BASE_URL = "https://api.fantasyfootballnerd.com/v1"
+DEFAULT_API_KEY = "TEST"
 
 
 def _get(endpoint: str, api_key: str | None = None, **params: Any) -> Dict[str, Any]:
-    key = api_key or os.getenv("FFN_API_KEY")
+    key = api_key or os.getenv("FFN_API_KEY", DEFAULT_API_KEY)
     if not key:
         raise ValueError("Fantasy Football Nerd API key is required")
     url = f"{BASE_URL}/{endpoint}/json/{key}"


### PR DESCRIPTION
## Summary
- default FFN API key `TEST` added for API client
- docs: update FFN API usage instructions

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6891871b1eb483219bc11abdfa3176a6