### PR TITLE
Use nflverse parquet releases for play-by-play data

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The frontend proxies requests under `/api` to the backend, so keep both processe
 ## Data Integration Outline
 
 - `backend/ffn_api.py` wraps the Fantasy Football Nerd API (uses the `FFN_API_KEY` environment variable and defaults to the key `TEST`).
-- `backend/nfl_data.py` fetches play-by-play data from the NFL fastR repository.
+- `backend/nfl_data.py` fetches play-by-play data from the nflverse data release (stored as `.parquet`).
 - `backend/data_service.py` demonstrates merging these sources into a single player pool loaded at server startup.
 
 This skeleton sets up the draft state management and provides a minimal React UI that lists available players. Further features—such as custom scoring, draft recommendations, and advanced analytics—can be built on top of this foundation.

--- a/backend/data_service.py
+++ b/backend/data_service.py
@@ -12,8 +12,8 @@ def load_player_pool(year: int = 2023) -> List[Dict]:
 
     The function combines:
     - Fantasy Football Nerd player list and current injuries.
-    - Historical play-by-play data from NFL fastR for simple metrics
-      such as games played or missed.
+    - Historical play-by-play data from the nflverse releases for
+      simple metrics such as games played or missed.
 
     Full stat/projection merging is left as a future enhancement.
     """
@@ -31,12 +31,12 @@ def load_player_pool(year: int = 2023) -> List[Dict]:
                 "position": p.get("position"),
                 "team": p.get("team"),
                 "injury": injury_map.get(pid),
-                # Placeholder: real implementation would merge stats from fastR
+                # Placeholder: real implementation would merge stats from nflverse
                 "rookie": False,
             }
         )
 
-    # Placeholder call to show how fastR data could be incorporated
+    # Placeholder call to show how nflverse data could be incorporated
     try:
         pbp = get_play_by_play(year)
         _ = len(pbp)  # suppress unused variable warning

--- a/backend/nfl_data.py
+++ b/backend/nfl_data.py
@@ -2,21 +2,23 @@ import pandas as pd
 import requests
 from pathlib import Path
 
-BASE_URL = "https://raw.githubusercontent.com/nflverse/nflverse-pbp/master/data"
+# Base download URL for nflverse play-by-play data releases
+BASE_URL = "https://github.com/nflverse/nflverse-data/releases/download/pbp"
 
 
 def get_play_by_play(year: int) -> pd.DataFrame:
     """Download play-by-play data for a given year.
 
     Data is cached locally under ``data/`` to avoid repeated downloads.
+    Files are stored as ``.parquet``.
     """
-    filename = Path("data") / f"play_by_play_{year}.csv.gz"
+    filename = Path("data") / f"play_by_play_{year}.parquet"
     if filename.exists():
-        return pd.read_csv(filename, compression="gzip")
+        return pd.read_parquet(filename)
 
-    url = f"{BASE_URL}/play_by_play_{year}.csv.gz"
+    url = f"{BASE_URL}/play_by_play_{year}.parquet"
     resp = requests.get(url, timeout=60)
     resp.raise_for_status()
     filename.parent.mkdir(parents=True, exist_ok=True)
     filename.write_bytes(resp.content)
-    return pd.read_csv(filename, compression="gzip")
+    return pd.read_parquet(filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pandas
+pyarrow
 requests
 fastapi
 uvicorn[standard]


### PR DESCRIPTION
## Summary
- pull play-by-play data from nflverse parquet releases instead of raw CSVs
- update docs and comments to reference nflverse data releases
- add pyarrow dependency for parquet support

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921ee8b5488321aa4d354c69c6ae15