### PR TITLE
Extend scoring rules with additional stats

### DIFF
--- a/scoring/calculator.py
+++ b/scoring/calculator.py
@@ -14,4 +14,8 @@ def calculate_points(stats: dict, rules: ScoringRules) -> float:
     points += s.get("rushing_yards", 0) * r.rushing_yards
     points += s.get("receiving_yards", 0) * r.receiving_yards
     points += s.get("interceptions", 0) * r.interception
+    points += s.get("fumble", 0) * r.fumble
+    points += s.get("two_point_conv", 0) * r.two_point_conv
+    points += s.get("field_goal_made", 0) * r.field_goal_made
+    points += s.get("extra_point", 0) * r.extra_point
     return points

--- a/scoring/rules.py
+++ b/scoring/rules.py
@@ -13,3 +13,7 @@ class ScoringRules:
     rushing_yards: float = 0.1
     receiving_yards: float = 0.1
     interception: float = -2.0
+    fumble: float = -2.0
+    two_point_conv: float = 2.0
+    field_goal_made: float = 3.0
+    extra_point: float = 1.0


### PR DESCRIPTION
## Summary
- support fumbles, two-point conversions, field goals made, and extra points in `ScoringRules`
- compute points for the new stats in `calculate_points`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68923517ce848321a6de93f594864eae