### PR TITLE
Add FFN injury and projection routes

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from .data_service import load_player_pool
 from .store import DraftState
+from . import ffn_api
 
 app = FastAPI(title="Draft Day Assistant")
 state = DraftState.load()
@@ -16,6 +17,31 @@ def startup() -> None:
 def get_players() -> list:
     """Return all available players."""
     return state.available_players
+
+
+@app.get("/ffn/players")
+def ffn_players() -> dict:
+    """Return raw player data from Fantasy Football Nerd."""
+    return ffn_api.get_players()
+
+
+@app.get("/injuries")
+def injuries() -> dict:
+    """Return current injury reports."""
+    return ffn_api.get_injuries()
+
+
+@app.get("/projections")
+def projections(
+    week: int = Query(..., ge=1, le=18),
+    position: str = Query(...),
+) -> dict:
+    """Return weekly projections for a position."""
+    pos = position.upper()
+    valid_positions = {"QB", "RB", "WR", "TE", "K", "DEF"}
+    if pos not in valid_positions:
+        raise HTTPException(status_code=400, detail="Invalid position")
+    return ffn_api.get_projections(week=week, position=pos)
 
 
 @app.post("/draft/pick")


### PR DESCRIPTION
## Summary
- expose raw Fantasy Football Nerd data via new `/ffn/players` route
- add `/injuries` route for current injury reports
- add `/projections` route with week/position query validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689235166f28832199ca310efdc9d734