### PR TITLE
Add helper functions for additional Fantasy Football Nerd API endpoints

### DIFF
--- a/backend/ffn_api.py
+++ b/backend/ffn_api.py
@@ -31,3 +31,100 @@ def get_injuries(api_key: str | None = None) -> Dict[str, Any]:
 def get_projections(week: int, position: str, api_key: str | None = None) -> Dict[str, Any]:
     """Return weekly projections for a position."""
     return _get("projections", api_key, week=week, position=position)
+
+
+def get_schedule(week: int, api_key: str | None = None) -> Dict[str, Any]:
+    """Return the NFL schedule for a given week.
+
+    Parameters
+    ----------
+    week : int
+        Regular-season week number.
+    api_key : str, optional
+        Fantasy Football Nerd API key.  If ``None`` the key is pulled from
+        ``FFN_API_KEY``.
+
+    Returns
+    -------
+    dict
+        Response payload with a top-level ``Schedule`` list.  Each element of
+        the list contains information about a game such as ``gameId``,
+        ``gameDate``, ``awayTeam``, ``homeTeam``, and kickoff time fields.
+    """
+
+    return _get("schedule", api_key, week=week)
+
+
+def get_depth_charts(team: str, api_key: str | None = None) -> Dict[str, Any]:
+    """Return the depth chart for a team.
+
+    Parameters
+    ----------
+    team : str
+        NFL team abbreviation (e.g., ``"GB"`` for Green Bay).
+    api_key : str, optional
+        Fantasy Football Nerd API key.  If ``None`` the key is pulled from
+        ``FFN_API_KEY``.
+
+    Returns
+    -------
+    dict
+        Response object with a ``DepthCharts`` mapping.  Each position key such
+        as ``QB`` or ``RB`` contains a list of players ordered by depth chart
+        rank.
+    """
+
+    return _get("depth-charts", api_key, team=team)
+
+
+def get_rankings(
+    week: int, position: str, api_key: str | None = None, ppr: bool = False
+) -> Dict[str, Any]:
+    """Return weekly fantasy player rankings.
+
+    Parameters
+    ----------
+    week : int
+        Regular-season week number.
+    position : str
+        Player position abbreviation (``QB``, ``RB``, ``WR``, ``TE``, ``K``,
+        or ``DEF``).
+    api_key : str, optional
+        Fantasy Football Nerd API key.  If ``None`` the key is pulled from
+        ``FFN_API_KEY``.
+    ppr : bool, optional
+        When ``True`` the rankings are returned using PPR scoring.  Defaults to
+        ``False``.
+
+    Returns
+    -------
+    dict
+        Response payload with a ``Rankings`` list of player dictionaries
+        containing fields such as ``playerId``, ``name``, ``team``, ``position``,
+        and ``rank``.
+    """
+
+    return _get(
+        "rankings", api_key, week=week, position=position, ppr=int(ppr)
+    )
+
+
+def get_bye_weeks(season: int, api_key: str | None = None) -> Dict[str, Any]:
+    """Return bye weeks for all teams in a season.
+
+    Parameters
+    ----------
+    season : int
+        Year of the NFL season.
+    api_key : str, optional
+        Fantasy Football Nerd API key.  If ``None`` the key is pulled from
+        ``FFN_API_KEY``.
+
+    Returns
+    -------
+    dict
+        Response object with a ``ByeWeeks`` list.  Each item contains the team
+        abbreviation and its corresponding bye week number.
+    """
+
+    return _get("bye-weeks", api_key, season=season)


### PR DESCRIPTION
## Summary
- implement `get_schedule`, `get_depth_charts`, `get_rankings`, and `get_bye_weeks`
- document required parameters and response structures for new helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689235154ca8832185c776e3daa016f8