### PR TITLE
Add draft context configuration to frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Player, Suggestion, ScoringRules } from "./types";
+import { Player, Suggestion, ScoringRules, LeagueContext } from "./types";
 import {
   initSeason,
   listPlayers,
@@ -7,6 +7,7 @@ import {
   draftPlayer,
   getDrafted,
   setRules as saveRulesApi,
+  setContext as saveContextApi,
   undraftPlayer,
 } from "./api";
 import DraftBoard from "./components/DraftBoard";
@@ -50,15 +51,23 @@ export default function App() {
     ppr: 0.5,
     te_premium: 0,
   });
+  const [context, setContextState] = useState<LeagueContext>({
+    snake: true,
+    teams: 12,
+    pick_slot: 1,
+    round: 1,
+    total_rounds: 16,
+    kdst_gate_round: 12,
+  });
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   // Team names (first = YOU / "ME")
   const defaultTeams = useMemo(
     () =>
-      Array.from({ length: rules.league_size }, (_, i) =>
+      Array.from({ length: context.teams }, (_, i) =>
         i === 0 ? "ME" : `Team ${i + 1}`
       ),
-    [rules.league_size]
+    [context.teams]
   );
   const [teamNames, setTeamNames] = useState<string[]>(defaultTeams);
 
@@ -126,6 +135,12 @@ export default function App() {
   const onSaveRules = async (r: ScoringRules) => {
     const saved = await saveRulesApi(r);
     setRules(saved);
+    await refreshLists();
+  };
+
+  const onSaveContext = async (c: LeagueContext) => {
+    const saved = await saveContextApi(c);
+    setContextState(saved);
     await refreshLists();
   };
 
@@ -265,7 +280,9 @@ export default function App() {
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         rules={rules}
-        onSave={onSaveRules}
+        context={context}
+        onSaveRules={onSaveRules}
+        onSaveContext={onSaveContext}
       />
     </div>
   );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,6 @@
 // frontend/src/api.ts
+import type { LeagueContext } from "./types";
+
 export const API_BASE =
   (import.meta as any).env?.VITE_API_BASE || "http://127.0.0.1:8000";
 
@@ -102,5 +104,13 @@ export async function setRules(rules: any) {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(rules)
+  }).then(r => r.json());
+}
+
+export async function setContext(ctx: LeagueContext) {
+  return fetch(`${API_BASE}/api/context`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(ctx)
   }).then(r => r.json());
 }

--- a/frontend/src/components/SettingsDrawer.tsx
+++ b/frontend/src/components/SettingsDrawer.tsx
@@ -1,19 +1,25 @@
 import React, { useState, useEffect } from "react";
-import { ScoringRules } from "../types";
+import { ScoringRules, LeagueContext } from "../types";
 
 export default function SettingsDrawer({
   open,
   onClose,
   rules,
-  onSave,
+  context,
+  onSaveRules,
+  onSaveContext,
 }: {
   open: boolean;
   onClose: () => void;
   rules: ScoringRules;
-  onSave: (r: ScoringRules) => void;
+  context: LeagueContext;
+  onSaveRules: (r: ScoringRules) => void | Promise<void>;
+  onSaveContext: (c: LeagueContext) => void | Promise<void>;
 }) {
-  const [form, setForm] = useState<ScoringRules>(rules);
-  useEffect(() => setForm(rules), [rules]);
+  const [formRules, setFormRules] = useState<ScoringRules>(rules);
+  const [formContext, setFormContext] = useState<LeagueContext>(context);
+  useEffect(() => setFormRules(rules), [rules]);
+  useEffect(() => setFormContext(context), [context]);
 
   // Safely read a number from a number input
   const nv = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -21,8 +27,12 @@ export default function SettingsDrawer({
     return Number.isNaN(n) ? 0 : n;
   };
 
-  const set = <K extends keyof ScoringRules>(k: K, v: number) =>
-    setForm((f) => ({ ...f, [k]: v }));
+  const setRule = <K extends keyof ScoringRules>(k: K, v: number) =>
+    setFormRules((f) => ({ ...f, [k]: v }));
+  const setCtx = <K extends keyof LeagueContext>(
+    k: K,
+    v: LeagueContext[K]
+  ) => setFormContext((f) => ({ ...f, [k]: v }));
 
   return (
     <>
@@ -36,85 +46,201 @@ export default function SettingsDrawer({
           <h4>Rosters</h4>
           <div className="drawer-grid3">
             <label>Teams
-              <input type="number" value={form.league_size}
-                onChange={(e) => set("league_size", nv(e))} />
+              <input
+                type="number"
+                value={formRules.league_size}
+                onChange={(e) => setRule("league_size", nv(e))}
+              />
             </label>
             <label>QB
-              <input type="number" value={form.roster_qb}
-                onChange={(e) => set("roster_qb", nv(e))} />
+              <input
+                type="number"
+                value={formRules.roster_qb}
+                onChange={(e) => setRule("roster_qb", nv(e))}
+              />
             </label>
             <label>RB
-              <input type="number" value={form.roster_rb}
-                onChange={(e) => set("roster_rb", nv(e))} />
+              <input
+                type="number"
+                value={formRules.roster_rb}
+                onChange={(e) => setRule("roster_rb", nv(e))}
+              />
             </label>
             <label>WR
-              <input type="number" value={form.roster_wr}
-                onChange={(e) => set("roster_wr", nv(e))} />
+              <input
+                type="number"
+                value={formRules.roster_wr}
+                onChange={(e) => setRule("roster_wr", nv(e))}
+              />
             </label>
             <label>TE
-              <input type="number" value={form.roster_te}
-                onChange={(e) => set("roster_te", nv(e))} />
+              <input
+                type="number"
+                value={formRules.roster_te}
+                onChange={(e) => setRule("roster_te", nv(e))}
+              />
             </label>
             <label>FLEX
-              <input type="number" value={form.roster_flex}
-                onChange={(e) => set("roster_flex", nv(e))} />
+              <input
+                type="number"
+                value={formRules.roster_flex}
+                onChange={(e) => setRule("roster_flex", nv(e))}
+              />
             </label>
             <label>DST
-              <input type="number" value={form.roster_dst}
-                onChange={(e) => set("roster_dst", nv(e))} />
+              <input
+                type="number"
+                value={formRules.roster_dst}
+                onChange={(e) => setRule("roster_dst", nv(e))}
+              />
             </label>
             <label>K
-              <input type="number" value={form.roster_k}
-                onChange={(e) => set("roster_k", nv(e))} />
+              <input
+                type="number"
+                value={formRules.roster_k}
+                onChange={(e) => setRule("roster_k", nv(e))}
+              />
             </label>
             <label>Bench
-              <input type="number" value={form.bench}
-                onChange={(e) => set("bench", nv(e))} />
+              <input
+                type="number"
+                value={formRules.bench}
+                onChange={(e) => setRule("bench", nv(e))}
+              />
             </label>
           </div>
 
           <h4>Scoring</h4>
           <div className="drawer-grid3">
             <label>Pass TD
-              <input type="number" step="0.1" value={form.pass_td}
-                onChange={(e) => set("pass_td", nv(e))} />
+              <input
+                type="number"
+                step="0.1"
+                value={formRules.pass_td}
+                onChange={(e) => setRule("pass_td", nv(e))}
+              />
             </label>
             <label>Pass Yd
-              <input type="number" step="0.01" value={form.pass_yd}
-                onChange={(e) => set("pass_yd", nv(e))} />
+              <input
+                type="number"
+                step="0.01"
+                value={formRules.pass_yd}
+                onChange={(e) => setRule("pass_yd", nv(e))}
+              />
             </label>
             <label>INT
-              <input type="number" step="0.1" value={form.pass_int}
-                onChange={(e) => set("pass_int", nv(e))} />
+              <input
+                type="number"
+                step="0.1"
+                value={formRules.pass_int}
+                onChange={(e) => setRule("pass_int", nv(e))}
+              />
             </label>
             <label>Rush TD
-              <input type="number" step="0.1" value={form.rush_td}
-                onChange={(e) => set("rush_td", nv(e))} />
+              <input
+                type="number"
+                step="0.1"
+                value={formRules.rush_td}
+                onChange={(e) => setRule("rush_td", nv(e))}
+              />
             </label>
             <label>Rush Yd
-              <input type="number" step="0.01" value={form.rush_yd}
-                onChange={(e) => set("rush_yd", nv(e))} />
+              <input
+                type="number"
+                step="0.01"
+                value={formRules.rush_yd}
+                onChange={(e) => setRule("rush_yd", nv(e))}
+              />
             </label>
             <label>Rec TD
-              <input type="number" step="0.1" value={form.rec_td}
-                onChange={(e) => set("rec_td", nv(e))} />
+              <input
+                type="number"
+                step="0.1"
+                value={formRules.rec_td}
+                onChange={(e) => setRule("rec_td", nv(e))}
+              />
             </label>
             <label>Rec Yd
-              <input type="number" step="0.01" value={form.rec_yd}
-                onChange={(e) => set("rec_yd", nv(e))} />
+              <input
+                type="number"
+                step="0.01"
+                value={formRules.rec_yd}
+                onChange={(e) => setRule("rec_yd", nv(e))}
+              />
             </label>
             <label>PPR
-              <input type="number" step="0.1" value={form.ppr}
-                onChange={(e) => set("ppr", nv(e))} />
+              <input
+                type="number"
+                step="0.1"
+                value={formRules.ppr}
+                onChange={(e) => setRule("ppr", nv(e))}
+              />
             </label>
             <label>TE Premium
-              <input type="number" step="0.1" value={form.te_premium}
-                onChange={(e) => set("te_premium", nv(e))} />
+              <input
+                type="number"
+                step="0.1"
+                value={formRules.te_premium}
+                onChange={(e) => setRule("te_premium", nv(e))}
+              />
+            </label>
+          </div>
+
+          <h4>Draft Context</h4>
+          <div className="drawer-grid3">
+            <label>Snake
+              <input
+                type="checkbox"
+                checked={formContext.snake}
+                onChange={(e) => setCtx("snake", e.currentTarget.checked)}
+              />
+            </label>
+            <label>Teams
+              <input
+                type="number"
+                value={formContext.teams}
+                onChange={(e) => setCtx("teams", nv(e))}
+              />
+            </label>
+            <label>Pick Slot
+              <input
+                type="number"
+                value={formContext.pick_slot}
+                onChange={(e) => setCtx("pick_slot", nv(e))}
+              />
+            </label>
+            <label>Round
+              <input
+                type="number"
+                value={formContext.round}
+                onChange={(e) => setCtx("round", nv(e))}
+              />
+            </label>
+            <label>Total Rounds
+              <input
+                type="number"
+                value={formContext.total_rounds}
+                onChange={(e) => setCtx("total_rounds", nv(e))}
+              />
+            </label>
+            <label>K/DST Gate Round
+              <input
+                type="number"
+                value={formContext.kdst_gate_round}
+                onChange={(e) => setCtx("kdst_gate_round", nv(e))}
+              />
             </label>
           </div>
 
           <div className="drawer-actions">
-            <button className="primary" onClick={() => { onSave(form); onClose(); }}>
+            <button
+              className="primary"
+              onClick={async () => {
+                await onSaveRules(formRules);
+                await onSaveContext(formContext);
+                onClose();
+              }}
+            >
               Save
             </button>
           </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -37,3 +37,13 @@ export type ScoringRules = {
   ppr: number
   te_premium: number
 }
+
+export type LeagueContext = {
+  snake: boolean
+  teams: number
+  pick_slot: number
+  round: number
+  total_rounds: number
+  kdst_gate_round: number
+}
+


### PR DESCRIPTION
## Summary
- add LeagueContext type and API function to set draft context
- extend settings drawer with draft context controls
- refresh suggestions based on saved draft context

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d23cc1fa08321a45d6c9396b6214c