### PR TITLE
Handle missing SportsData API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Open http://localhost:5173
 
 If your backend runs elsewhere, add `VITE_API_BASE=http://localhost:8000` to a `frontend/.env` file.
 
+### Environment variable
+
+The backend requires a `SPORTSDATA_API_KEY` in the environment. For local development, put it in `backend/.env` (from `.env.example`). For production deployments, export `SPORTSDATA_API_KEY` so the server can fetch player data. Without this key, `/api/init` will return an error and no players will load.
+
 ---
 
 ## What it uses

--- a/backend/app.py
+++ b/backend/app.py
@@ -88,6 +88,8 @@ async def api_init(season: Optional[str] = None):
         raw = await fetch_all_data(season)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"SportsData fetch failed: {e}")
+    if isinstance(raw, dict) and raw.get("error"):
+        raise HTTPException(status_code=500, detail=raw["error"])
 
     normalized = normalize_players(raw)
 

--- a/backend/providers/sportsdata.py
+++ b/backend/providers/sportsdata.py
@@ -93,7 +93,15 @@ async def fetch_all_data(season: str) -> Dict[str, Any]:
     injuries (best effort), and fallback season stats (prev year) if projections are empty.
     """
     if not API_KEY:
-        raise RuntimeError("Missing SportsData.io API key (set SPORTSDATA_API_KEY).")
+        return {
+            "players": [],
+            "byes": [],
+            "depth": [],
+            "projections": [],
+            "season_stats": [],
+            "injuries": [],
+            "error": "Missing SportsData.io API key (set SPORTSDATA_API_KEY).",
+        }
 
     s = _season_clean(season)
     year = int(s)


### PR DESCRIPTION
## Summary
- Return a descriptive error with empty data when `SPORTSDATA_API_KEY` is not configured
- Surface provider error in `/api/init`
- Document `SPORTSDATA_API_KEY` requirement for local and production setups

## Testing
- `python -m py_compile backend/providers/sportsdata.py backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689e847bb6508321a2eaa1e6509e79cc