### PR TITLE
Handle initSeason failure to show error message

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -113,9 +113,14 @@ export default function App() {
   // First load: init season then fetch lists
   useEffect(() => {
     (async () => {
-      await initSeason(season);
-      setInitd(true);
-      await refreshLists();
+      try {
+        await initSeason(season);
+        setInitd(true);
+        await refreshLists();
+      } catch (err) {
+        console.error("initSeason failed", err);
+        setError("Failed to initialize season");
+      }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## Summary
- surface initialization errors in the draft assistant by catching `initSeason` failures and setting an error state

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e847ea17083218ef1955baf6f67ed